### PR TITLE
Update GTCASpaceMiningAsteroids.java

### DIFF
--- a/src/main/java/net/mordgren/gtca/common/machine/multiblock/electric/miner/data/GTCASpaceMiningAsteroids.java
+++ b/src/main/java/net/mordgren/gtca/common/machine/multiblock/electric/miner/data/GTCASpaceMiningAsteroids.java
@@ -7,9 +7,16 @@ import net.mordgren.gtca.common.machine.multiblock.electric.miner.registry.Space
 
 public final class GTCASpaceMiningAsteroids {
 
+    private static boolean initialized = false;
+
     private GTCASpaceMiningAsteroids() {}
 
     public static void init() {
+        if (initialized) {
+            GTCA.LOGGER.info("[SpaceMining] GTCASpaceMiningAsteroids.init() already called, skipping duplicate registration.");
+            return;
+        }
+
         GTCA.LOGGER.info("[SpaceMining] GTCASpaceMiningAsteroids.init() called");
 
         AsteroidBuilder.asteroid(GTCA.id("asteroid/coal"))
@@ -26,6 +33,7 @@ public final class GTCASpaceMiningAsteroids {
                 .ore(GTMaterials.Graphite, 0.30)
                 .buildAndRegister();
 
+        initialized = true;
         GTCA.LOGGER.info("[SpaceMining] Registered asteroids = {}", SpaceMiningRegistry.size());
     }
 }


### PR DESCRIPTION
The problem is that the init() method is called several times (for example, with each reload of datapacks or when creating a new world), and each time it tries to register the asteroid gtca:asteroid/coal. Because the SpaceMiningRegistry is not cleared between calls, re-registration is attempted, causing IllegalStateException.
Here is the corrected code with the addition of the initialized flag, which prevents reinitialization: